### PR TITLE
Extensible visitors

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -39,9 +39,8 @@ export function extractClientData<I: {}, O>(
   endpoint: SafeAPI.Endpoint<I, O>,
   input: I
 ): ClientData<I> {
-  const visit: SafeAPI.Visit<ClientDataF, I> = SafeAPI.makeVisitor(endpoint);
-  const clientData = visit(clientDataVisitor);
-  return clientData(input);
+  const visit: SafeAPI.Visit<ClientDataF, I> = SafeAPI.makeVisit(endpoint);
+  return visit(clientDataVisitor)(input);
 }
 
 export async function safeGet<I: {}, O>(

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ interface Middleware<I_old: {}, I: {}> {
    example.
   */
 
-  visit<DataF: Function>(
+  _visit<DataF: Function>(
     visitor: Visitor<DataF>
   ): ($Call<DataF, I_old>) => $Call<DataF, I>;
 }
@@ -35,7 +35,7 @@ export class Fragment<I: {}> implements Middleware<I, I> {
   constructor(urlFragment: string) {
     this.urlFragment = urlFragment;
   }
-  visit<DataF: Function>(
+  _visit<DataF: Function>(
     visitor: Visitor<DataF>
   ): ($Call<DataF, I>) => $Call<DataF, I> {
     return visitor.handleFragment(this.urlFragment);
@@ -51,7 +51,7 @@ export class QueryParams<I: {}, P: {}>
   constructor(params: P) {
     this.params = params;
   }
-  visit<DataF: Function>(
+  _visit<DataF: Function>(
     visitor: Visitor<DataF>
   ): ($Call<DataF, I>) => $Call<DataF, $Merge<I, $ExtractTypes<P>>> {
     return visitor.handleQueryParams(this.params);
@@ -59,7 +59,7 @@ export class QueryParams<I: {}, P: {}>
 }
 
 export interface Endpoint<I: {}, O> {
-  visit<DataF: Function>(visitor: Visitor<DataF>): $Call<DataF, I>;
+  _visit<DataF: Function>(visitor: Visitor<DataF>): $Call<DataF, I>;
   append<I_new: {}>(middleware: Middleware<I, I_new>): Endpoint<I_new, O>;
   fragment(urlFragment: string): Endpoint<I, O>;
   queryParams<P: {}>(params: P): Endpoint<$Merge<I, $ExtractTypes<P>>, O>;
@@ -68,7 +68,7 @@ export interface Endpoint<I: {}, O> {
 export class EndpointImpl<I: {}, O> implements Endpoint<I, O> {
   constructor() {}
 
-  visit<DataF: Function>(visitor: Visitor<DataF>): $Call<DataF, I> {
+  _visit<DataF: Function>(visitor: Visitor<DataF>): $Call<DataF, I> {
     throw "abstract method";
   }
 
@@ -97,14 +97,14 @@ export class Snoc<I_old: {}, O_old, I: {}, O> extends EndpointImpl<I, O> {
     this.data = data;
   }
 
-  visit<DataF: Function>(visitor: Visitor<DataF>): $Call<DataF, I> {
+  _visit<DataF: Function>(visitor: Visitor<DataF>): $Call<DataF, I> {
     const { previous, middleware } = this.data;
-    return middleware.visit(visitor)(previous.visit(visitor));
+    return middleware._visit(visitor)(previous._visit(visitor));
   }
 }
 
 export class Nil<O> extends EndpointImpl<{}, O> {
-  visit<DataF: Function>(visitor: Visitor<DataF>): $Call<DataF, {}> {
+  _visit<DataF: Function>(visitor: Visitor<DataF>): $Call<DataF, {}> {
     return visitor.init();
   }
 }
@@ -115,6 +115,6 @@ export function endpoint<O>(): Endpoint<{}, O> {
 
 export type Visit<DataF: Function, I> = (Visitor<DataF>) => $Call<DataF, I>;
 
-export function makeVisitor<I: {}, O>(endpoint: Endpoint<I, O>): Visit<*, I> {
-  return endpoint.visit.bind(endpoint);
+export function makeVisit<I: {}, O>(endpoint: Endpoint<I, O>): Visit<*, I> {
+  return endpoint._visit.bind(endpoint);
 }

--- a/src/server.js
+++ b/src/server.js
@@ -35,7 +35,7 @@ const serverDataVisitor: SafeAPI.Visitor<ServerDataF> = {
 export function extractServerData<I: {}, O>(
   endpoint: SafeAPI.Endpoint<I, O>
 ): ServerData<I> {
-  const visit: SafeAPI.Visit<ServerDataF, I> = SafeAPI.makeVisitor(endpoint);
+  const visit: SafeAPI.Visit<ServerDataF, I> = SafeAPI.makeVisit(endpoint);
   return visit(serverDataVisitor);
 }
 


### PR DESCRIPTION
This changes the base implementation of endpoints and middleware to allow for a generic visitor pattern, instead of hardcoding the specific `mapServerData` and `mapClientData` methods we used to have. That way we can separate the definition of endpoints and middleware from the definitions of visitors/"interpreters" of those types, which are defined by pattern matching on all the various cases.

As a result we could have the following package structure:
- `safe-api-base` is where all the base definitions of endpoints are done, which basically give a well-typed alternative to using the string type for URLs (and also specifying query parameters etc.)
- a number of packages that wrap popular libraries, like `safe-api-fetch` and `safe-api-koa`, which define their own interpreters/visitors of the base types, giving well-typed versions of their basic methods

This does introduce a bit of complexity, as it requires the use of higher-kinded types for typing the generic `visit` function correctly and maintaining all type information. (I have added an explanation in the code about how higher-kinded types are encoded in Flow. An example of such a type we have used already is `$ObjMap<Keys, F>` -- `F` is a type-level function transforming the types of values of an object, and therefore has the higher kind `Type -> Type`.) I do think the extra complexity is well-warranted though; we have discussed with @sleexyz that being able to define new interpreters of the endpoint constructors is necessary in order to be able to add wrapper APIs for more libraries as independent NPM packages.

Closes #21 .