### PR TITLE
Continuous Delivery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2
 jobs:
-  build:
+  check:
     docker:
       - image: node:8.7.0
     steps:
       - checkout
       - run:
-          name: Install dependencies
+          name: Install package dependencies
           command: yarn
       - run:
           name: Build packages
@@ -14,3 +14,61 @@ jobs:
       - run:
           name: Checks
           command: yarn check-all
+      - run:
+          name: Initialize workspace
+          command: cp -R . /tmp/project
+      - persist_to_workspace:
+          root: /tmp/project
+          paths: .
+
+  deploy-canary:
+    docker:
+      - image: node:8.7.0
+    steps:
+      - attach_workspace:
+          at: /tmp/project
+      - run:
+          name: Set up NPM auth token
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - run:
+          name: Publish packages
+          command: cd /tmp/project && ./scripts/ci-publish-canary.sh
+
+  deploy-release:
+    docker:
+      - image: node:8.7.0
+    steps:
+      - attach_workspace:
+          at: /tmp/project
+      - run:
+          name: Set up NPM auth token
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - run:
+          name: Set up git identity
+          command: git config --global user.email "circleci@circleci" && git config --global user.name "CircleCI"
+      - run:
+          name: Install deployment dependencies
+          command: apt-get update && apt-get install jq
+      - add-ssh-keys:
+          fingerprints:
+            - "35:ed:9b:95:c9:aa:c9:9c:47:df:04:28:0e:97:59:a8" # read-write github.com
+      - run:
+          name: Publish packages
+          command: cd /tmp/project && ./scripts/ci-publish-release.sh
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - check
+      - deploy-canary:
+          requires:
+            - check
+          filters:
+            branches:
+              only:
+                - master
+      - deploy-release:
+          type: approval
+          requires:
+            - deploy-canary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           root: /tmp/project
           paths: .
 
-  deploy-canary:
+  publish-canary:
     docker:
       - image: node:8.7.0
     steps:
@@ -34,7 +34,7 @@ jobs:
           name: Publish packages
           command: cd /tmp/project && ./scripts/ci-publish-canary.sh
 
-  deploy-release:
+  publish-release:
     docker:
       - image: node:8.7.0
     steps:
@@ -47,7 +47,7 @@ jobs:
           name: Set up git identity
           command: git config --global user.email "circleci@circleci" && git config --global user.name "CircleCI"
       - run:
-          name: Install deployment dependencies
+          name: Install publishing dependencies
           command: apt-get update && apt-get install jq
       - add-ssh-keys:
           fingerprints:
@@ -58,17 +58,17 @@ jobs:
 
 workflows:
   version: 2
-  build-deploy:
+  build-publish:
     jobs:
       - check
-      - deploy-canary:
+      - publish-canary:
           requires:
             - check
           filters:
             branches:
               only:
                 - master
-      - deploy-release:
+      - publish-release:
           type: approval
           requires:
-            - deploy-canary
+            - publish-canary

--- a/scripts/ci-publish-canary.sh
+++ b/scripts/ci-publish-canary.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+./node_modules/.bin/lerna publish --skip-git --canary --yes

--- a/scripts/ci-publish-release.sh
+++ b/scripts/ci-publish-release.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+./node_modules/.bin/lerna publish --skip-git --yes
+git ls-files | grep '\package.json$' | xargs git add
+VERSION=$(cd recouple; yarn info --json | jq '.data.version' --raw-output)
+git commit  -m "[ci skip] version bump: $VERSION"
+git push origin HEAD

--- a/scripts/ci-publish-release.sh
+++ b/scripts/ci-publish-release.sh
@@ -2,7 +2,7 @@
 set -e
 
 ./node_modules/.bin/lerna publish --skip-git --yes
-git ls-files | grep '\package.json$' | xargs git add
+git ls-files | grep 'package.json$' | xargs git add
 VERSION=$(cd recouple; yarn info --json | jq '.data.version' --raw-output)
 git commit  -m "[ci skip] version bump: $VERSION"
 git push origin HEAD

--- a/scripts/ci-publish-release.sh
+++ b/scripts/ci-publish-release.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-./node_modules/.bin/lerna publish --skip-git --yes
+./node_modules/.bin/lerna publish --skip-git --yes --cd-version minor
 git ls-files | grep 'package.json$' | xargs git add
 VERSION=$(cd recouple; yarn info --json | jq '.data.version' --raw-output)
 git commit  -m "[ci skip] version bump: $VERSION"


### PR DESCRIPTION
This PR introduces two new CircleCI workflow steps: `publish-canary` and `publish-release`.

![2017-12-02-23 39 50](https://user-images.githubusercontent.com/1505617/33522479-bcb9e766-d7bb-11e7-9f96-b32b7eceb6ed.png)


### `publish-canary`
Publishes a [canary release](https://github.com/lerna/lerna#--canary--c), like `recouple@0.2.0-alpha.462af61f`. The minor version number is incremented from the one in the repo. These versions can be downloaded from npm, but will not be the versions downloaded when running `yarn add recouple`, for example.

Runs on every push to `master`.

Does NOT push a commit to `master`.

### `publish-release`
Publishes a release, like `recouple@0.2.0`. The minor version number is incremented from the one in the repo. These versions will be the ones downloaded when running `yarn add recouple`, for example.

Runs on every push to `master`.

Pushes a commit to `master` with the incremented version numbers in the `package.json`'s.

---

This PR makes use of two new secrets: 
- an auth token for Originate's npm account.
- a private key for github read/write ssh access. This can be regenerated with a PR if lost.

Neither are checked in the repo. At some point we might need to figure out secrets managements, i.e. add blackbox or something.

---

Closes #44 
