### PR TITLE
Hook up release step properly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,10 @@ workflows:
             branches:
               only:
                 - master
-      - publish-release:
+      - trigger-publish-release:
           type: approval
           requires:
             - publish-canary
+      - publish-release:
+          requires:
+            - trigger-publish-release


### PR DESCRIPTION
The `publish-release` job actually wasn't being triggered when approved on CircleCI. CircleCi requires you to create a separate "approval job" for triggers, and then declare the triggered job a dependant of the "approval job".