### PR TITLE
WIP add number type reps

### DIFF
--- a/integration-tests/src/query_params.test.js
+++ b/integration-tests/src/query_params.test.js
@@ -91,6 +91,21 @@ describe("for a GET endpoint with no parameters", () => {
       last: "Last"
     });
   });
+
+  test("server will parse empty inputs on non optional parameters as empty strings", async () => {
+    const server = TestUtils.makeServer({
+      endpoint: testEndpoint,
+      handler: testHandler
+    });
+    const resp = await fetch(
+      `http://localhost:${server.address().port}/foo?first=&last=Last`
+    );
+    await resp.json();
+    expect(testHandler).toHaveBeenLastCalledWith({
+      first: "",
+      last: "Last"
+    });
+  });
 });
 
 const testNumEndpoint: Recouple.Endpoint<
@@ -105,7 +120,7 @@ const testNumEndpoint: Recouple.Endpoint<
   });
 
 const testNumHandler = jest.fn(async () => {
-  return 47;
+  return 0;
 });
 
 describe("for a GET endpoint with number query parameters", () => {
@@ -133,7 +148,7 @@ describe("for a GET endpoint with number query parameters", () => {
         `http://localhost:${server.address().port}/foo?x=47`
       );
       await resp.json();
-      expect(testNumEndpoint).toHaveBeenLastCalledWith({ x: 47 });
+      expect(testNumHandler).toHaveBeenLastCalledWith({ x: 47 });
     });
   });
 });
@@ -219,12 +234,12 @@ describe("for a GET endpoint with optional query parameters", () => {
       });
     });
 
-    test("server will parse empty inputs as the empty string", async () => {
+    test("server will parse empty inputs on optional parameters as null", async () => {
       const resp = await fetch(
         `http://localhost:${server.address().port}/foo?x=&y=Y`
       );
       await resp.json();
-      expect(testOptionalHandler).toHaveBeenLastCalledWith({ x: "", y: "Y" });
+      expect(testOptionalHandler).toHaveBeenLastCalledWith({ x: null, y: "Y" });
     });
   });
 });

--- a/integration-tests/src/query_params.test.js
+++ b/integration-tests/src/query_params.test.js
@@ -93,6 +93,51 @@ describe("for a GET endpoint with no parameters", () => {
   });
 });
 
+const testNumEndpoint: Recouple.Endpoint<
+  {
+    x: number
+  },
+  number
+> = Recouple.endpoint()
+  .fragment("foo")
+  .queryParams({
+    x: T.number
+  });
+
+const testNumHandler = jest.fn(async () => {
+  return 47;
+});
+
+describe("for a GET endpoint with number query parameters", () => {
+  let server;
+  beforeEach(() => {
+    server = TestUtils.makeServer({
+      endpoint: testNumEndpoint,
+      handler: testNumHandler
+    });
+  });
+
+  describe("for the recouple client", () => {
+    it("can be called with a query parameter", async () => {
+      const baseURL = `http://localhost:${server.address().port}`;
+      const input = { x: 47 };
+      await RecoupleFetch.safeGet(baseURL, testNumEndpoint, input);
+      const expectedURL = `${baseURL}/foo?x=47`;
+      expect(fetch).toHaveBeenLastCalledWith(expectedURL);
+    });
+  });
+
+  describe("for the recouple server", () => {
+    it("can be called with a query parameter", async () => {
+      const resp = await fetch(
+        `http://localhost:${server.address().port}/foo?x=47`
+      );
+      await resp.json();
+      expect(testNumEndpoint).toHaveBeenLastCalledWith({ x: 47 });
+    });
+  });
+});
+
 const testOptionalEndpoint: Recouple.Endpoint<
   {
     x: ?string,

--- a/recouple-koa/src/index.js
+++ b/recouple-koa/src/index.js
@@ -61,7 +61,8 @@ export function safeGet<I: {}, O>(
 
     const rawQueryParams = queryString.parse(context.request.querystring);
     for (const key of Object.keys(data.queryParams)) {
-      input[key] = rawQueryParams[key];
+      const tRep = data.queryParams[key];
+      input[key] = tRep.deserialize(rawQueryParams[key]);
     }
     data.captureParams.forEach((key, index) => {
       input[key] = args[index];

--- a/recouple/src/__tests__/index.test.js
+++ b/recouple/src/__tests__/index.test.js
@@ -79,3 +79,69 @@ describe("endpoint", () => {
     });
   });
 });
+
+// type-level tests
+() => {
+  // ok
+  (endpoint().queryParams({ id: T.number }): Recouple.Endpoint<
+    { id: number },
+    string
+  >);
+
+  // $FlowFixMe
+  (endpoint().queryParams({ id: T.number }): Recouple.Endpoint<
+    { id: string },
+    string
+  >);
+
+  // ok
+  (endpoint().queryParams({ id: T.nullValue }): Recouple.Endpoint<
+    { id: null },
+    string
+  >);
+
+  // $FlowFixMe
+  (endpoint().queryParams({ id: T.nullValue }): Recouple.Endpoint<
+    { id: typeof undefined },
+    string
+  >);
+
+  // $FlowFixMe
+  (endpoint().queryParams({ id: T.nullValue }): Recouple.Endpoint<
+    { id: string },
+    string
+  >);
+
+  // ok
+  (endpoint().queryParams({ id: T.undefinedValue }): Recouple.Endpoint<
+    { id: typeof undefined },
+    string
+  >);
+
+  // $FlowFixMe
+  (endpoint().queryParams({ id: T.undefinedValue }): Recouple.Endpoint<
+    { id: null },
+    string
+  >);
+
+  // $FlowFixMe
+  (endpoint().queryParams({ id: T.undefinedValue }): Recouple.Endpoint<
+    { id: string },
+    string
+  >);
+
+  // ok
+  (endpoint().queryParams({
+    id: T.union(T.number, T.string)
+  }): Recouple.Endpoint<{ id: number | string }, string>);
+
+  // $FlowFixMe
+  (endpoint().queryParams({
+    id: T.union(T.number, T.string)
+  }): Recouple.Endpoint<{ id: number }, string>);
+
+  // ok
+  (endpoint().queryParams({
+    id: T.maybe(T.string)
+  }): Recouple.Endpoint<{ id: ?string }, string>);
+};

--- a/recouple/src/type_rep.js
+++ b/recouple/src/type_rep.js
@@ -2,4 +2,30 @@
 export interface TypeRep<T> {}
 
 class StringRep implements TypeRep<string> {}
+class NumRep implements TypeRep<number> {}
+class NullRep implements TypeRep<null> {}
+class UndefinedRep implements TypeRep<typeof undefined> {}
+class UnionRep<A, B> implements TypeRep<A | B> {
+  left: A;
+  right: B;
+  constructor(a: A, b: B) {
+    this.left = a;
+    this.right = b;
+  }
+}
+
 export const string = new StringRep();
+export const number = new NumRep();
+export const nullValue = new NullRep();
+export const undefinedValue = new UndefinedRep();
+
+export function union<A, B, T: TypeRep<A>, U: TypeRep<B>>(
+  left: T,
+  right: U
+): TypeRep<A | B> {
+  return new UnionRep(left, right);
+}
+
+export function maybe<A, T: TypeRep<A>>(t: T): TypeRep<?A> {
+  return union(t, union(nullValue, undefinedValue));
+}

--- a/recouple/src/type_rep.js
+++ b/recouple/src/type_rep.js
@@ -1,15 +1,40 @@
 // @flow
-// eslint-disable-next-line no-unused-vars
-export interface TypeRep<T> {}
+export interface TypeRep<T> {
+  deserialize(input: string): T;
+}
 
-class StringRep implements TypeRep<string> {}
-class NumRep implements TypeRep<number> {}
-class OptionRep<T> implements TypeRep<?T> {}
+class StringRep implements TypeRep<string> {
+  deserialize(input: string): string {
+    return input;
+  }
+}
+
+class NumRep implements TypeRep<number> {
+  deserialize(input: string): number {
+    const num = Number.parseInt(input);
+    if (!isNaN(num)) {
+      return num;
+    } else throw new Error("cannot parse number");
+  }
+}
+
+class OptionRep<T> implements TypeRep<?T> {
+  inner: TypeRep<T>;
+  constructor(inner: TypeRep<T>) {
+    this.inner = inner;
+  }
+  deserialize(input: string): ?T {
+    if (input === "") {
+      return null;
+    } else {
+      return this.inner.deserialize(input);
+    }
+  }
+}
 
 export const string = new StringRep();
 export const number = new NumRep();
 
-// eslint-disable-next-line no-unused-vars
 export function option<T, Rep: TypeRep<T>>(value: Rep): TypeRep<?T> {
-  return new OptionRep();
+  return new OptionRep(value);
 }


### PR DESCRIPTION
Add `number`, `null` and `undefined` as type reps available for query params. Also defines a type rep union. Defines `maybe` in terms of type unions.

To(potentially)Do: Let capture params capture numbers. @astampoulis I glanced at this, it looks non trivial.

#23