### PR TITLE
actually actually fix ci release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,6 @@ jobs:
           name: Set up NPM auth token
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run:
-          name: Trust github.com
-          command: ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - run:
           name: Set up git identity
           command: git config --global user.email "circleci@circleci" && git config --global user.name "CircleCI"
       - run:
@@ -55,6 +52,9 @@ jobs:
       - add-ssh-keys:
           fingerprints:
             - "35:ed:9b:95:c9:aa:c9:9c:47:df:04:28:0e:97:59:a8" # read-write github.com
+      - run:
+          name: Trust github.com
+          command: mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run:
           name: Publish packages
           command: cd /tmp/project && ./scripts/ci-publish-release.sh


### PR DESCRIPTION
Sorry I should've actually tested this in an ssh session... Now it should definitely work

Before:
```
root@7cdb502d49ac:/tmp/project# git pull
The authenticity of host 'github.com (192.30.253.112)' can't be established.
RSA key fingerprint is 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)?
```

After:
```
root@7cdb502d49ac:/tmp/project# mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
# github.com SSH-2.0-libssh_0.7.0
# github.com SSH-2.0-libssh_0.7.0
no hostkey alg
# github.com SSH-2.0-libssh_0.7.0
no hostkey alg
root@7cdb502d49ac:/tmp/project# git pull
Warning: Permanently added the RSA host key for IP address '192.30.253.113' to the list of known hosts.
Already up-to-date.
```