### PR TITLE
Serialize nums in query params with type reps

### DIFF
--- a/integration-tests/src/query_params.test.js
+++ b/integration-tests/src/query_params.test.js
@@ -234,12 +234,12 @@ describe("for a GET endpoint with optional query parameters", () => {
       });
     });
 
-    test("server will parse empty inputs on optional parameters as null", async () => {
+    test("server will parse empty inputs on optional parameters as empty", async () => {
       const resp = await fetch(
         `http://localhost:${server.address().port}/foo?x=&y=Y`
       );
       await resp.json();
-      expect(testOptionalHandler).toHaveBeenLastCalledWith({ x: null, y: "Y" });
+      expect(testOptionalHandler).toHaveBeenLastCalledWith({ x: "", y: "Y" });
     });
   });
 });

--- a/integration-tests/src/query_params.test.js
+++ b/integration-tests/src/query_params.test.js
@@ -91,6 +91,21 @@ describe("for a GET endpoint with no parameters", () => {
       last: "Last"
     });
   });
+
+  test("server will parse empty inputs on non optional parameters as empty strings", async () => {
+    const server = TestUtils.makeServer({
+      endpoint: testEndpoint,
+      handler: testHandler
+    });
+    const resp = await fetch(
+      `http://localhost:${server.address().port}/foo?first=&last=Last`
+    );
+    await resp.json();
+    expect(testHandler).toHaveBeenLastCalledWith({
+      first: "",
+      last: "Last"
+    });
+  });
 });
 
 const testNumEndpoint: Recouple.Endpoint<
@@ -105,7 +120,7 @@ const testNumEndpoint: Recouple.Endpoint<
   });
 
 const testNumHandler = jest.fn(async () => {
-  return 47;
+  return 0;
 });
 
 describe("for a GET endpoint with number query parameters", () => {
@@ -133,7 +148,7 @@ describe("for a GET endpoint with number query parameters", () => {
         `http://localhost:${server.address().port}/foo?x=47`
       );
       await resp.json();
-      expect(testNumEndpoint).toHaveBeenLastCalledWith({ x: 47 });
+      expect(testNumHandler).toHaveBeenLastCalledWith({ x: 47 });
     });
   });
 });
@@ -219,12 +234,12 @@ describe("for a GET endpoint with optional query parameters", () => {
       });
     });
 
-    test("server will parse empty inputs as the empty string", async () => {
+    test("server will parse empty inputs on optional parameters as null", async () => {
       const resp = await fetch(
         `http://localhost:${server.address().port}/foo?x=&y=Y`
       );
       await resp.json();
-      expect(testOptionalHandler).toHaveBeenLastCalledWith({ x: "", y: "Y" });
+      expect(testOptionalHandler).toHaveBeenLastCalledWith({ x: null, y: "Y" });
     });
   });
 });

--- a/integration-tests/src/query_params.test.js
+++ b/integration-tests/src/query_params.test.js
@@ -196,7 +196,7 @@ describe("for a GET endpoint with optional query parameters", () => {
         expect(fetch).toHaveBeenLastCalledWith(expectedURL);
       });
 
-      it("will omit undefined parameters", async () => {
+      it("will strip undefined parameters from the query string", async () => {
         const baseURL = `http://localhost:${server.address().port}`;
         const input = { x: undefined, y: "Y" };
         await RecoupleFetch.safeGet(baseURL, testOptionalEndpoint, input);

--- a/integration-tests/src/query_params.test.js
+++ b/integration-tests/src/query_params.test.js
@@ -93,6 +93,51 @@ describe("for a GET endpoint with no parameters", () => {
   });
 });
 
+const testNumEndpoint: Recouple.Endpoint<
+  {
+    x: number
+  },
+  number
+> = Recouple.endpoint()
+  .fragment("foo")
+  .queryParams({
+    x: T.number
+  });
+
+const testNumHandler = jest.fn(async () => {
+  return 47;
+});
+
+describe("for a GET endpoint with number query parameters", () => {
+  let server;
+  beforeEach(() => {
+    server = TestUtils.makeServer({
+      endpoint: testNumEndpoint,
+      handler: testNumHandler
+    });
+  });
+
+  describe("for the recouple client", () => {
+    it("can be called with a query parameter", async () => {
+      const baseURL = `http://localhost:${server.address().port}`;
+      const input = { x: 47 };
+      await RecoupleFetch.safeGet(baseURL, testNumEndpoint, input);
+      const expectedURL = `${baseURL}/foo?x=47`;
+      expect(fetch).toHaveBeenLastCalledWith(expectedURL);
+    });
+  });
+
+  describe("for the recouple server", () => {
+    it("can be called with a query parameter", async () => {
+      const resp = await fetch(
+        `http://localhost:${server.address().port}/foo?x=47`
+      );
+      await resp.json();
+      expect(testNumEndpoint).toHaveBeenLastCalledWith({ x: 47 });
+    });
+  });
+});
+
 const testOptionalEndpoint: Recouple.Endpoint<
   {
     x: ?string,

--- a/integration-tests/src/query_params.test.js
+++ b/integration-tests/src/query_params.test.js
@@ -92,7 +92,7 @@ describe("for a GET endpoint with no parameters", () => {
     });
   });
 
-  test("server will parse empty inputs on non optional parameters as empty strings", async () => {
+  test("server will parse empty inputs on non-optional parameters as empty strings", async () => {
     const server = TestUtils.makeServer({
       endpoint: testEndpoint,
       handler: testHandler
@@ -119,9 +119,7 @@ const testNumEndpoint: Recouple.Endpoint<
     x: T.number
   });
 
-const testNumHandler = jest.fn(async () => {
-  return 0;
-});
+const testNumHandler = jest.fn(async () => 0);
 
 describe("for a GET endpoint with number query parameters", () => {
   let server;

--- a/recouple-koa/src/index.js
+++ b/recouple-koa/src/index.js
@@ -61,7 +61,8 @@ export function safeGet<I: {}, O>(
 
     const rawQueryParams = queryString.parse(context.request.querystring);
     for (const key of Object.keys(data.queryParams)) {
-      input[key] = rawQueryParams[key];
+      const tRep = data.queryParams[key];
+      input[key] = tRep.deserialize(rawQueryParams[key]);
     }
     data.captureParams.forEach((key, index) => {
       input[key] = args[index];

--- a/recouple/src/__tests__/index.test.js
+++ b/recouple/src/__tests__/index.test.js
@@ -79,3 +79,69 @@ describe("endpoint", () => {
     });
   });
 });
+
+// type-level tests
+() => {
+  // ok
+  (endpoint().queryParams({ id: T.number }): Recouple.Endpoint<
+    { id: number },
+    string
+  >);
+
+  // $FlowFixMe
+  (endpoint().queryParams({ id: T.number }): Recouple.Endpoint<
+    { id: string },
+    string
+  >);
+
+  // ok
+  (endpoint().queryParams({ id: T.nullValue }): Recouple.Endpoint<
+    { id: null },
+    string
+  >);
+
+  // $FlowFixMe
+  (endpoint().queryParams({ id: T.nullValue }): Recouple.Endpoint<
+    { id: typeof undefined },
+    string
+  >);
+
+  // $FlowFixMe
+  (endpoint().queryParams({ id: T.nullValue }): Recouple.Endpoint<
+    { id: string },
+    string
+  >);
+
+  // ok
+  (endpoint().queryParams({ id: T.undefinedValue }): Recouple.Endpoint<
+    { id: typeof undefined },
+    string
+  >);
+
+  // $FlowFixMe
+  (endpoint().queryParams({ id: T.undefinedValue }): Recouple.Endpoint<
+    { id: null },
+    string
+  >);
+
+  // $FlowFixMe
+  (endpoint().queryParams({ id: T.undefinedValue }): Recouple.Endpoint<
+    { id: string },
+    string
+  >);
+
+  // ok
+  (endpoint().queryParams({
+    id: T.union(T.number, T.string)
+  }): Recouple.Endpoint<{ id: number | string }, string>);
+
+  // $FlowFixMe
+  (endpoint().queryParams({
+    id: T.union(T.number, T.string)
+  }): Recouple.Endpoint<{ id: number }, string>);
+
+  // ok
+  (endpoint().queryParams({
+    id: T.maybe(T.string)
+  }): Recouple.Endpoint<{ id: ?string }, string>);
+};

--- a/recouple/src/type_rep.js
+++ b/recouple/src/type_rep.js
@@ -2,4 +2,30 @@
 export interface TypeRep<T> {}
 
 class StringRep implements TypeRep<string> {}
+class NumRep implements TypeRep<number> {}
+class NullRep implements TypeRep<null> {}
+class UndefinedRep implements TypeRep<typeof undefined> {}
+class UnionRep<A, B> implements TypeRep<A | B> {
+  left: A;
+  right: B;
+  constructor(a: A, b: B) {
+    this.left = a;
+    this.right = b;
+  }
+}
+
 export const string = new StringRep();
+export const number = new NumRep();
+export const nullValue = new NullRep();
+export const undefinedValue = new UndefinedRep();
+
+export function union<A, B, T: TypeRep<A>, U: TypeRep<B>>(
+  left: T,
+  right: U
+): TypeRep<A | B> {
+  return new UnionRep(left, right);
+}
+
+export function maybe<A, T: TypeRep<A>>(t: T): TypeRep<?A> {
+  return union(t, union(nullValue, undefinedValue));
+}

--- a/recouple/src/type_rep.js
+++ b/recouple/src/type_rep.js
@@ -1,15 +1,40 @@
 // @flow
-// eslint-disable-next-line no-unused-vars
-export interface TypeRep<T> {}
+export interface TypeRep<T> {
+  deserialize(input: string): T;
+}
 
-class StringRep implements TypeRep<string> {}
-class NumRep implements TypeRep<number> {}
-class OptionRep<T> implements TypeRep<?T> {}
+class StringRep implements TypeRep<string> {
+  deserialize(input: string): string {
+    return input;
+  }
+}
+
+class NumRep implements TypeRep<number> {
+  deserialize(input: string): number {
+    const num = Number.parseInt(input);
+    if (!isNaN(num)) {
+      return num;
+    } else throw new Error("cannot parse number");
+  }
+}
+
+class OptionRep<T> implements TypeRep<?T> {
+  inner: TypeRep<T>;
+  constructor(inner: TypeRep<T>) {
+    this.inner = inner;
+  }
+  deserialize(input: string): ?T {
+    if (input === "") {
+      return null;
+    } else {
+      return this.inner.deserialize(input);
+    }
+  }
+}
 
 export const string = new StringRep();
 export const number = new NumRep();
 
-// eslint-disable-next-line no-unused-vars
 export function option<T, Rep: TypeRep<T>>(value: Rep): TypeRep<?T> {
-  return new OptionRep();
+  return new OptionRep(value);
 }

--- a/recouple/src/type_rep.js
+++ b/recouple/src/type_rep.js
@@ -7,9 +7,8 @@ class StringRep implements TypeRep<string> {
   deserialize(input: ?string): string {
     if (input == null) {
       throw new Error("cannot deserialize null to string");
-    } else {
-      return input;
     }
+    return input;
   }
 }
 
@@ -17,14 +16,12 @@ class NumRep implements TypeRep<number> {
   deserialize(input: ?string): number {
     if (input == null) {
       throw new Error("cannot deserialize null to number");
-    } else {
-      const num = Number.parseInt(input);
-      if (isNaN(num)) {
-        throw new Error("cannot parse number");
-      } else {
-        return num;
-      }
     }
+    const num = Number.parseInt(input);
+    if (isNaN(num)) {
+      throw new Error("cannot parse number");
+    }
+    return num;
   }
 }
 
@@ -36,9 +33,8 @@ class OptionRep<T> implements TypeRep<?T> {
   deserialize(input: ?string): ?T {
     if (input == null) {
       return input;
-    } else {
-      return this.inner.deserialize(input);
     }
+    return this.inner.deserialize(input);
   }
 }
 

--- a/recouple/src/type_rep.js
+++ b/recouple/src/type_rep.js
@@ -1,20 +1,30 @@
 // @flow
 export interface TypeRep<T> {
-  deserialize(input: string): T;
+  deserialize(input: ?string): T;
 }
 
 class StringRep implements TypeRep<string> {
-  deserialize(input: string): string {
-    return input;
+  deserialize(input: ?string): string {
+    if (input == null) {
+      throw new Error("cannot deserialize null to string");
+    } else {
+      return input;
+    }
   }
 }
 
 class NumRep implements TypeRep<number> {
-  deserialize(input: string): number {
-    const num = Number.parseInt(input);
-    if (!isNaN(num)) {
-      return num;
-    } else throw new Error("cannot parse number");
+  deserialize(input: ?string): number {
+    if (input == null) {
+      throw new Error("cannot deserialize null to number");
+    } else {
+      const num = Number.parseInt(input);
+      if (isNaN(num)) {
+        throw new Error("cannot parse number");
+      } else {
+        return num;
+      }
+    }
   }
 }
 
@@ -23,9 +33,9 @@ class OptionRep<T> implements TypeRep<?T> {
   constructor(inner: TypeRep<T>) {
     this.inner = inner;
   }
-  deserialize(input: string): ?T {
-    if (input === "") {
-      return null;
+  deserialize(input: ?string): ?T {
+    if (input == null) {
+      return input;
     } else {
       return this.inner.deserialize(input);
     }


### PR DESCRIPTION
This adds numbers to type reps and allows them to be used for query params. In order to implement this we had to add `deserialize` to TypeRep so that numbers are interpreted as such and not as strings. I imagine there will be some discussion about wether TypeRep should contain logic. For now, we _only_ use TypeRep for things to be deserialized. If in the future we have a need to then we should refactor and split `Serializable` apart from `TypeRep`. 

ToDo: Use allow number to be used for capture params.

#23 