### PR TITLE
remove unnecessary runtime dependencies of recouple

### DIFF
--- a/recouple/package.json
+++ b/recouple/package.json
@@ -16,13 +16,8 @@
     "eslint-plugin-jest": "^21.3.2",
     "flow-copy-source": "^1.2.1",
     "jest": "^21.2.1",
+    "koa-route": "^3.2.0",
     "prettier": "^1.8.2"
-  },
-  "dependencies": {
-    "babel-core": "^6.26.0",
-    "isomorphic-fetch": "^2.2.1",
-    "koa": "^2.4.1",
-    "koa-route": "^3.2.0"
   },
   "scripts": {
     "build": "yarn build-babel && yarn build-flow",


### PR DESCRIPTION
If you just want to use `recouple` (and not necessarily `recouple-fetch` or `recouple-koa`) you don't need any of `babel-core`, `isomorphic-fetch`, `koa` or `koa-route`. `koa-route` is used in the test-suite though.